### PR TITLE
Feat/gazebo ignition

### DIFF
--- a/rbvogui_description/launch/robot_state_publisher.launch.py
+++ b/rbvogui_description/launch/robot_state_publisher.launch.py
@@ -49,6 +49,7 @@ def read_params(ld : launch.LaunchDescription):
     launch_joint = launch.substitutions.LaunchConfiguration('launch_joint')
     kinematics = launch.substitutions.LaunchConfiguration('kinematics')
     controllers_file = launch.substitutions.LaunchConfiguration('controllers_file')
+    simulator = launch.substitutions.LaunchConfiguration('simulator')
 
     # Declare the launch options
     ld.add_action(launch.actions.DeclareLaunchArgument(
@@ -119,6 +120,12 @@ def read_params(ld : launch.LaunchDescription):
             default_value=[get_package_share_directory('rbvogui_gazebo'), '/config/', kinematics, '_controller.yaml'])
     )
 
+    ld.add_action(launch.actions.DeclareLaunchArgument(
+        name='simulator',
+        description='simulator (classic or ignition)',
+        default_value='classic')
+    )
+
 
     # Parse the launch options
     ret = {}
@@ -133,7 +140,8 @@ def read_params(ld : launch.LaunchDescription):
         'connected': connected,
         'launch_joint': launch_joint,
         'kinematics': kinematics,
-        'controllers_file': controllers_file
+        'controllers_file': controllers_file,
+        'simulator': simulator
         }
     
     else:
@@ -177,6 +185,10 @@ def read_params(ld : launch.LaunchDescription):
             ret['controllers_file'] = os.environ['CONTROLLERS_FILE']
         else:  ret['controllers_file'] = controllers_file
 
+        if 'SIMULATOR' in os.environ:
+            ret['simulator'] = os.environ['SIMULATOR']
+        else: ret['simulator'] = simulator
+
 
     return ret
 
@@ -201,7 +213,8 @@ def generate_launch_description():
             " hq:=true",
             " cart:=", params['cart'],
             " connected:=", params['connected'],
-            " controllers:=", params['controllers_file']
+            " controllers:=", params['controllers_file'],
+            " simulator:=", params['simulator']
         ]
     )
 

--- a/rbvogui_description/robots/macros/rbvogui_std.urdf.xacro
+++ b/rbvogui_description/robots/macros/rbvogui_std.urdf.xacro
@@ -32,7 +32,7 @@
     <xacro:property name="hq" value="true" />
     <xacro:property name="publish_bf" value="true" />
 
-    <xacro:macro name="rbvogui" params="prefix publish_bf hq kinematics gpu robot_id controllers">
+    <xacro:macro name="rbvogui" params="prefix publish_bf hq kinematics gpu robot_id controllers simulator:='classic'">
 
         <!-- ***************   -->
         <!-- Robots Elements -->
@@ -82,30 +82,30 @@
         <!-- SENSORS see robotnik_sensors for the specific configuration -->
 
         <!-- IMU -->
-        <xacro:sensor_vectornav prefix="${prefix}" parent="${prefix}chassis_link" topic="/${robot_id}/imu/data">
+        <xacro:sensor_vectornav prefix="${prefix}" parent="${prefix}chassis_link" topic="/${robot_id}/imu/data" simulator="${simulator}">
             <origin xyz="0.3 -0.3 0.0725" rpy="0 0 0"/>
         </xacro:sensor_vectornav>
 
         <!-- Front Camera -->
-        <xacro:sensor_intel_d435 prefix="${prefix}front_rgbd_camera" parent="${prefix}chassis_link" prefix_topic="/${robot_id}/front_rgbd_camera" use_nominal_extrinsics="true">
+        <xacro:sensor_intel_d435 prefix="${prefix}front_rgbd_camera" parent="${prefix}chassis_link" prefix_topic="/${robot_id}/front_rgbd_camera" use_nominal_extrinsics="true" simulator="${simulator}">
             <origin xyz="0.46462 0.0 0.18258" rpy="0 0 0"/>
         </xacro:sensor_intel_d435>
 
         <!-- Rear Camera -->
-        <xacro:sensor_intel_d435 prefix="${prefix}rear_rgbd_camera" parent="${prefix}base_link" prefix_topic="/${robot_id}/rear_rgbd_camera" use_nominal_extrinsics="true">
+        <xacro:sensor_intel_d435 prefix="${prefix}rear_rgbd_camera" parent="${prefix}base_link" prefix_topic="/${robot_id}/rear_rgbd_camera" use_nominal_extrinsics="true" simulator="${simulator}">
             <origin xyz="-0.503 0.0 0.29" rpy="0 0 -${PI}"/>
         </xacro:sensor_intel_d435>
 
         <!-- 2d laser -->
-        <xacro:sensor_sick_s300 prefix="${prefix}front_laser" parent="${prefix}chassis_link" gpu="${gpu}" prefix_topic="/${robot_id}/front_laser">
+        <xacro:sensor_sick_s300 prefix="${prefix}front_laser" parent="${prefix}chassis_link" gpu="${gpu}" prefix_topic="/${robot_id}/front_laser" simulator="${simulator}">
           <origin xyz="0.53 0.33 0.1145" rpy="${PI} 0 ${PI/4}"/>
         </xacro:sensor_sick_s300>
 
-        <xacro:sensor_sick_s300 prefix="${prefix}rear_laser" parent="${prefix}chassis_link" gpu="${gpu}" prefix_topic="/${robot_id}/rear_laser">
+        <xacro:sensor_sick_s300 prefix="${prefix}rear_laser" parent="${prefix}chassis_link" gpu="${gpu}" prefix_topic="/${robot_id}/rear_laser" simulator="${simulator}">
           <origin xyz="-0.53 -0.33 0.1145" rpy="${PI} 0 ${-PI*3/4}"/>
         </xacro:sensor_sick_s300>
 
-        <xacro:ros2_control prefix="${prefix}" robot_id="${robot_id}" controllers="${controllers}"/>
+        <xacro:ros2_control prefix="${prefix}" robot_id="${robot_id}" controllers="${controllers}" simulator="${simulator}"/>
 
     </xacro:macro>
 

--- a/rbvogui_description/robots/rbvogui.urdf.xacro
+++ b/rbvogui_description/robots/rbvogui.urdf.xacro
@@ -19,9 +19,10 @@
     <xacro:arg name="gpu" default="true" />
     <xacro:arg name="kinematics" default="omni" />
     <xacro:arg name="controllers" default="$(find rbvogui_gazebo)/config/omni_controller.yaml" />
+    <xacro:arg name="simulator" default="classic" />
 
     <xacro:rbvogui robot_id="$(arg robot_id)" prefix="$(arg prefix)" kinematics="$(arg kinematics)" gpu="$(arg gpu)" publish_bf="${publish_bf}" hq="${hq}"
-                    controllers="$(arg controllers)"/>
+                    controllers="$(arg controllers)" simulator="$(arg simulator)"/>
 
 
     <!-- Cart -->

--- a/rbvogui_description/urdf/ros2_control.urdf.xacro
+++ b/rbvogui_description/urdf/ros2_control.urdf.xacro
@@ -1,42 +1,62 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
-    <xacro:macro name="ros2_control" params="prefix robot_id controllers">
-        <gazebo>
-          <plugin name="ros_control" filename="libgazebo_ros2_control.so">
-            <namespace>${robot_id}</namespace>
-            <robot_param>robot_description</robot_param>
-            <robot_param_node>robot_state_publisher</robot_param_node>
-            <parameters>${controllers}</parameters>
-          </plugin>
-        </gazebo>
+  <!-- Define the ros2_joint macro outside of ros2_control -->
+  <xacro:macro name="ros2_joint" params="interface jmin jmax prefix name">
+    <joint name="${prefix}${name}">
+      <command_interface name="${interface}">
+        <param name="min">${jmin}</param>
+        <param name="max">${jmax}</param>
+      </command_interface>
+      <state_interface name="position" />
+      <state_interface name="velocity" />
+      <state_interface name="effort" />
+    </joint>
+  </xacro:macro>
 
-        <xacro:macro name="ros2_joint" params="interface jmin jmax prefix name">
-          <joint name="${prefix}${name}">
-            <command_interface name="${interface}">
-              <param name="min">${jmin}</param>
-              <param name="max">${jmax}</param>
-            </command_interface>
-            <state_interface name="position"/>
-            <state_interface name="velocity"/>
-            <state_interface name="effort"/>
-          </joint>
-        </xacro:macro>
+  <!-- Define the ros2_control macro that includes plugins for Gazebo Classic or Ignition -->
+  <xacro:macro name="ros2_control" params="prefix robot_id controllers simulator">
+    <gazebo>
+      <xacro:if value="${simulator == 'ignition'}">
+        <plugin name="ign_ros2_control::IgnitionROS2ControlPlugin" filename="ign_ros2_control-system">
+          <ros>
+            <namespace>${robot_id}</namespace>  <!-- Define the namespace for the robot -->
+          </ros>
+          <robotParam>robot_description</robotParam>  <!-- Namespace for the robot parameter -->
+          <robotParamNode>robot_state_publisher</robotParamNode>  <!-- Node name for the control manager -->
+          <parameters>${controllers}</parameters>
+        </plugin>
+      </xacro:if>
+      <xacro:if value="${simulator == 'classic'}">
+        <plugin name="ros_control" filename="libgazebo_ros2_control.so">
+          <ros>
+            <namespace>${robot_id}</namespace>  <!-- Define the namespace for the robot -->
+          </ros>
+          <robotParam>robot_description</robotParam>  <!-- Namespace for the robot parameter -->
+          <robotParamNode>robot_state_publisher</robotParamNode>  <!-- Node name for the control manager -->
+          <parameters>${controllers}</parameters>
+        </plugin>
+      </xacro:if>
+    </gazebo>
 
-        <ros2_control name="GazeboSystem" type="system">
-          <hardware>
-              <plugin>gazebo_ros2_control/GazeboSystem</plugin>
-          </hardware>
+    <ros2_control name="GazeboSystem" type="system">
+      <hardware>
+        <xacro:if value="${simulator == 'classic'}">
+          <plugin>gazebo_ros2_control/GazeboSystem</plugin>
+        </xacro:if>
+        <xacro:if value="${simulator == 'ignition'}">
+          <plugin>ign_ros2_control/IgnitionSystem</plugin>
+        </xacro:if>
+      </hardware>
 
-          <xacro:ros2_joint interface="position" jmin="-2" jmax="2" prefix="${prefix}" name="front_left_steering_joint"/>
-          <xacro:ros2_joint interface="position" jmin="-2" jmax="2" prefix="${prefix}" name="front_right_steering_joint"/>
-          <xacro:ros2_joint interface="position" jmin="-2" jmax="2" prefix="${prefix}" name="back_left_steering_joint"/>
-          <xacro:ros2_joint interface="position" jmin="-2" jmax="2" prefix="${prefix}" name="back_right_steering_joint"/>
-
-          <xacro:ros2_joint interface="velocity" jmin="-10" jmax="10" prefix="${prefix}" name="front_left_wheel_joint"/>
-          <xacro:ros2_joint interface="velocity" jmin="-10" jmax="10" prefix="${prefix}" name="front_right_wheel_joint"/>
-          <xacro:ros2_joint interface="velocity" jmin="-20" jmax="20" prefix="${prefix}" name="back_left_wheel_joint"/>
-          <xacro:ros2_joint interface="velocity" jmin="-20" jmax="20" prefix="${prefix}" name="back_right_wheel_joint"/>
-
-        </ros2_control>
-    </xacro:macro>
+      <!-- Calls to the ros2_joint macro to create joints -->
+      <xacro:ros2_joint interface="position" jmin="-2" jmax="2" prefix="${prefix}" name="front_left_steering_joint" />
+      <xacro:ros2_joint interface="position" jmin="-2" jmax="2" prefix="${prefix}" name="front_right_steering_joint" />
+      <xacro:ros2_joint interface="position" jmin="-2" jmax="2" prefix="${prefix}" name="back_left_steering_joint" />
+      <xacro:ros2_joint interface="position" jmin="-2" jmax="2" prefix="${prefix}" name="back_right_steering_joint" />
+      <xacro:ros2_joint interface="velocity" jmin="-10" jmax="10" prefix="${prefix}" name="front_left_wheel_joint" />
+      <xacro:ros2_joint interface="velocity" jmin="-10" jmax="10" prefix="${prefix}" name="front_right_wheel_joint" />
+      <xacro:ros2_joint interface="velocity" jmin="-20" jmax="20" prefix="${prefix}" name="back_left_wheel_joint" />
+      <xacro:ros2_joint interface="velocity" jmin="-20" jmax="20" prefix="${prefix}" name="back_right_wheel_joint" />
+    </ros2_control>
+  </xacro:macro>
 </robot>


### PR DESCRIPTION
Vogui simulation migrated to gazebo ignition not loosing the gazebo classic compatibility. It depends on the following package updates:
rbvogui_common:
type: git
url: https://github.com/RobotnikAutomation/rbvogui_common
version: feat/gazebo_ignition
rbvogui_sim:
type: git
url: https://github.com/RobotnikAutomation/rbvogui_sim
version: feat/gazebo_ignition
robotnik_sensors:
type: git
url: https://github.com/RobotnikAutomation/robotnik_sensors
version: feat/gazebo_ignition